### PR TITLE
The FormRowType should know the type of cell that it should be presented by

### DIFF
--- a/SwiftForms/Source/controllers/FormViewController.swift
+++ b/SwiftForms/Source/controllers/FormViewController.swift
@@ -13,14 +13,7 @@ import UIKit
 }
 
 class FormViewController : UITableViewController {
-
-    /// MARK: Types
-    
-    struct Static {
-        static var onceDefaultCellClass: dispatch_once_t = 0
-        static var defaultCellClasses: [FormRowType : FormBaseCell.Type] = [:]
-    }
-    
+   
     /// MARK: Properties
     
     var form: FormDescriptor!
@@ -180,34 +173,6 @@ class FormViewController : UITableViewController {
         }
     }
     
-    private class func defaultCellClassForRowType(rowType: FormRowType) -> FormBaseCell.Type {
-        dispatch_once(&Static.onceDefaultCellClass) {
-            Static.defaultCellClasses[FormRowType.Text] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.Number] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.NumbersAndPunctuation] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.Decimal] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.Name] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.Phone] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.URL] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.Twitter] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.NamePhone] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.Email] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.ASCIICapable] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.Password] = FormTextFieldCell.self
-            Static.defaultCellClasses[FormRowType.Button] = FormButtonCell.self
-            Static.defaultCellClasses[FormRowType.BooleanSwitch] = FormSwitchCell.self
-            Static.defaultCellClasses[FormRowType.BooleanCheck] = FormCheckCell.self
-            Static.defaultCellClasses[FormRowType.SegmentedControl] = FormSegmentedControlCell.self
-            Static.defaultCellClasses[FormRowType.Picker] = FormPickerCell.self
-            Static.defaultCellClasses[FormRowType.Date] = FormDateCell.self
-            Static.defaultCellClasses[FormRowType.Time] = FormDateCell.self
-            Static.defaultCellClasses[FormRowType.DateAndTime] = FormDateCell.self
-            Static.defaultCellClasses[FormRowType.MultipleSelector] = FormSelectorCell.self
-            Static.defaultCellClasses[FormRowType.MultilineText] = FormTextViewCell.self
-        }
-        return Static.defaultCellClasses[rowType]!
-    }
-    
     private func formRowDescriptorAtIndexPath(indexPath: NSIndexPath!) -> FormRowDescriptor {
         let section = form.sections[indexPath.section]
         let rowDescriptor = section.rows[indexPath.row]
@@ -219,7 +184,7 @@ class FormViewController : UITableViewController {
         var formBaseCellClass: FormBaseCell.Type!
         
         if rowDescriptor.cellClass == nil { // fallback to default cell class
-            formBaseCellClass = FormViewController.defaultCellClassForRowType(rowDescriptor.rowType)
+            formBaseCellClass = rowDescriptor.rowType.classForRowType()
         }
         else {
             formBaseCellClass = rowDescriptor.cellClass as? FormBaseCell.Type

--- a/SwiftForms/Source/descriptors/FormRowDescriptor.swift
+++ b/SwiftForms/Source/descriptors/FormRowDescriptor.swift
@@ -32,6 +32,32 @@ enum FormRowType {
     case DateAndTime
     case MultipleSelector
     case MultilineText
+  
+    func classForRowType() -> FormBaseCell.Type {
+        switch self {
+        case .Text, .Number, .NumbersAndPunctuation, .Decimal,
+        .Name, .Phone, .URL, .Twitter, .NamePhone, .Email, .ASCIICapable,
+        .Password, .MultilineText:
+            return FormTextFieldCell.self
+        case .Button:
+            return FormButtonCell.self
+        case .BooleanSwitch:
+            return FormSwitchCell.self
+        case .BooleanCheck:
+            return FormCheckCell.self
+        case .SegmentedControl:
+            return FormSegmentedControlCell.self
+        case .Picker:
+            return FormPickerCell.self
+        case .Date, .Time, .DateAndTime:
+            return FormDateCell.self
+        case .MultipleSelector:
+            return FormSelectorCell.self
+        case .Unknown:
+            assert(false, "Error: Unknown cell type")
+            return FormTextFieldCell.self
+        }
+    }
 }
 
 typealias TitleFormatter = (NSObject) -> String!


### PR DESCRIPTION
This has the benefit of giving a compile error if a new FormRowType case is not defined.