### PR TITLE
Fix FormPickerCell crash from stale data counts

### DIFF
--- a/SwiftForms/cells/FormPickerCell.swift
+++ b/SwiftForms/cells/FormPickerCell.swift
@@ -31,6 +31,7 @@ public class FormPickerCell: FormValueCell, UIPickerViewDelegate, UIPickerViewDa
     public override func update() {
         super.update()
         
+        picker.reloadAllComponents()
         titleLabel.text = rowDescriptor.title
         
         if let value = rowDescriptor.value {


### PR DESCRIPTION
When a FormPickerCell is reused with a different row descriptor,
`update()` is called but the picker's cached data source counts are not
invalidated, which can cause a crash when the expected and actual data
counts do not match.