### PR TITLE
Fixed remove methods

### DIFF
--- a/SwiftForms/descriptors/FormDescriptor.swift
+++ b/SwiftForms/descriptors/FormDescriptor.swift
@@ -28,7 +28,7 @@ public class FormDescriptor {
     }
     
     public func removeSectionAtIndex(index: Int) throws {
-        guard index >= 0 && index < sections.count - 1 else { throw FormErrorType.SectionOutOfIndex }
+        guard index >= 0 && index <= sections.count - 1 else { throw FormErrorType.SectionOutOfIndex }
         sections.removeAtIndex(index)
     }
     

--- a/SwiftForms/descriptors/FormSectionDescriptor.swift
+++ b/SwiftForms/descriptors/FormSectionDescriptor.swift
@@ -33,7 +33,7 @@ public class FormSectionDescriptor {
         self.rows.appendContentsOf(rows)
     }
     public func removeRowAtIndex(index: Int) throws {
-        guard index >= 0 && index < rows.count - 1 else { throw FormErrorType.RowOutOfIndex }
+        guard index >= 0 && index <= rows.count - 1 else { throw FormErrorType.RowOutOfIndex }
         rows.removeAtIndex(index)
     }
 }


### PR DESCRIPTION
There is an issue with removing rows from sections and also removing sections from table. 
Invalid top indexes are applied in guards. Please include and release to Cocoapods and Carthage. 

Fixed removeSectionAtIndex method.

Invalid top boundary was applied, therefore the last row/section cannot be deleted and the workflow led to throwing FormErrorType.RowOutOfIndex.