### PR TITLE
Modify example app to fix placeholders (#162)

### DIFF
--- a/SwiftFormsApplication/ExampleFormViewController.swift
+++ b/SwiftFormsApplication/ExampleFormViewController.swift
@@ -66,35 +66,42 @@ class ExampleFormViewController: FormViewController {
         let section1 = FormSectionDescriptor(headerTitle: nil, footerTitle: nil)
         
         var row = FormRowDescriptor(tag: Static.emailTag, type: .email, title: "Email")
-        row.configuration.cell.appearance = ["textField.placeholder" : "john@gmail.com" as AnyObject, "textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.appearance = ["textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.placeholder = "john@gmail.com"
         section1.rows.append(row)
 
         row = FormRowDescriptor(tag: Static.passwordTag, type: .password, title: "Password")
-        row.configuration.cell.appearance = ["textField.placeholder" : "Enter password" as AnyObject, "textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.appearance = ["textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.placeholder = "Enter password"
         section1.rows.append(row)
         
         let section2 = FormSectionDescriptor(headerTitle: nil, footerTitle: nil)
         
         row = FormRowDescriptor(tag: Static.nameTag, type: .name, title: "First Name")
-        row.configuration.cell.appearance = ["textField.placeholder" : "e.g. Miguel Ángel" as AnyObject, "textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.appearance = ["textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.placeholder = "e.g. Miguel Ángel"
         section2.rows.append(row)
         
         row = FormRowDescriptor(tag: Static.lastNameTag, type: .name, title: "Last Name")
-        row.configuration.cell.appearance = ["textField.placeholder" : "e.g. Ortuño" as AnyObject, "textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.appearance = ["textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.placeholder = "e.g. Ortuño"
         section2.rows.append(row)
         
         row = FormRowDescriptor(tag: Static.jobTag, type: .text, title: "Job")
-        row.configuration.cell.appearance = ["textField.placeholder" : "e.g. Entrepreneur" as AnyObject, "textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.appearance = ["textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.placeholder = "e.g. Entrepreneur"
         section2.rows.append(row)
         
         let section3 = FormSectionDescriptor(headerTitle: nil, footerTitle: nil)
 
         row = FormRowDescriptor(tag: Static.URLTag, type: .url, title: "URL")
-        row.configuration.cell.appearance = ["textField.placeholder" : "e.g. gethooksapp.com" as AnyObject, "textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.appearance = ["textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.placeholder = "e.g. gethooksapp.com"
         section3.rows.append(row)
         
         row = FormRowDescriptor(tag: Static.phoneTag, type: .phone, title: "Phone")
-        row.configuration.cell.appearance = ["textField.placeholder" : "e.g. 0034666777999" as AnyObject, "textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.appearance = ["textField.textAlignment" : NSTextAlignment.right.rawValue as AnyObject]
+        row.configuration.cell.placeholder = "e.g. 0034666777999"
         section3.rows.append(row)
         
         let section4 = FormSectionDescriptor(headerTitle: "An example header title", footerTitle: "An example footer title")


### PR DESCRIPTION
When the user entered some text in any of the cells and left the cell empty after that, the placeholder was not appearing any more. With these changes, the placeholder appears again when the text of the cell is empty.

Fixes the following issue: #162 placeholder text disappear when textfield is erased